### PR TITLE
Add support for ClojureScript REPL sessions during development

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1,0 +1,20 @@
+# Notes for development in this project
+
+As this project matures this may need more structure/organization.
+
+
+## Starting a ClojureScript REPL
+
+After starting a normal Leiningen REPL, follow the following steps:
+
+````
+user=> (use 'figwheel-sidecar.repl-api)
+user=> (start-figwheel!)
+user=> (cljs-repl)
+Launching ClojureScript REPL for build: REPL
+;; The compiled clara-tools files should be available.
+cljs.user=> clara.tools.client.bootstrap/panel
+#object[reagent.impl.template.NativeWrapper]
+````
+
+Then open the file "clara-tools/resources/public/index.html" in your browser.

--- a/project.clj
+++ b/project.clj
@@ -17,26 +17,49 @@
                  [javax.servlet/servlet-api "2.5"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [prismatic/schema "1.0.3"]
-                 [figwheel-sidecar "0.5.4-6"]]
+                 [figwheel-sidecar "0.5.7"]
+                 [com.cemerick/piggieback "0.2.1"]]
 
   :resource-paths ["resources" "target/resources"]
   :source-paths ["src/main/clojure"]
   :test-paths ["src/test/clojure"]
   :java-source-paths ["src/main/java"]
   :lein-release {:deploy-via :clojars}
-  :plugins [[lein-cljsbuild "1.1.3"]
-            [lein-figwheel "0.5.4-7"]]
+  :plugins [[lein-cljsbuild "1.1.4"]
+            [lein-figwheel "0.5.7"]]
   :hooks [leiningen.cljsbuild]
+
+  :jar-exclusions [#".*index\.html$" #".*repl\/public\/js.*"]
 
   :figwheel {:ring-handler clara.tools.impl.server/app
              :nrepl-port 7888}
 
+  :profiles {:dev {:dependencies [[com.cemerick/piggieback "0.2.1"]]}}
+
   :cljsbuild {:builds
-              [{:source-paths ["src/main/clojurescript"]
+              [
+               ;; The REPL build should be excluded from compiled jars; it just exists
+               ;; to provide a build conforming with Figwheel's expectations so that
+               ;; we can run a ClojureScript REPL during development.  The crucial difference
+               ;; is that the expected asset-path by consumers and by Figwheel is different.
+               ;; TODO: Determine if these can be unified by some means.
+               {:source-paths ["src/main/clojurescript"]
                 :figwheel true
-                :externs ["externs.js"]
+                :id "REPL"
                 :compiler {
-                           :main clara.tools.client.main
+                           :main "clara.tools.client.main"
+                           :externs [ "externs.js" ]
+                           :asset-path "../../target/resources/repl/public/js"
+                           :output-to "target/resources/repl/public/js/clara-tools.js"
+                           :output-dir "target/resources/repl/public/js"
+                           :optimizations :none
+                           :pretty-print true}}
+
+               {:source-paths ["src/main/clojurescript"]
+                :id "MAIN"
+                :compiler {
+                           :main "clara.tools.client.main"
+                           :externs [ "externs.js" ]
                            :asset-path "/public/js"
                            :output-to "target/resources/public/js/clara-tools.js"
                            :output-dir "target/resources/public/js"

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">    
+    <!-- <link href="css/style.css" rel="stylesheet" type="text/css"> -->
+  </head>
+  <body>
+    <div id="app">
+      <h2>Figwheel template</h2>
+      <p>Checkout your developer console.</p>
+    </div>
+    <script src="../../target/resources/repl/public/js/clara-tools.js" type="text/javascript"></script>
+  </body>
+</html>


### PR DESCRIPTION
- Updated the cljsbuild and figwheel-sidecar versions
- Added the piggieback dev dependency, which seems to be required for a Figwheel cljs REPL.
- Since Figwheel expects an HTML file to be opened for a REPL per its documentation at https://github.com/bhauman/lein-figwheel under "Try Figwheel" I added this file, but added it to the jar-exclusions so that it won't clutter the deployed artifact.
- Since Figwheel expects the asset-path to be relative to the HTML file used, and the assets are in the target folder, it needs a different :asset-path than the deployed artifact uses.  I added another build and added its files to the jar-exclusions as well to get around this.
- Added development notes with how to start a ClojureScript REPL in this project.
- The cljsbuild plugin seems to expect the :externs key to be under the :compiler options; the current placement caused problems for Figwheel and is not the expected structure set out at https://github.com/emezeske/lein-cljsbuild/blob/1.1.4/sample.project.clj  I changed this so that each build has an :externs key and things worked as expected.
